### PR TITLE
Bugfix: generate absolute filename for spawn process

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -335,7 +335,7 @@ class Extension {
         var outDir = path.dirname(sessionState.prgfilename);
         Utils.mkdirRecursive(outDir);
 
-        var executable = settings.assemblerPath;
+        var executable = Utils.getAbsoluteFilename(settings.assemblerPath);
         var args = [
             "-f", "cbm",
             "-o", sessionState.prgfilename,
@@ -402,7 +402,7 @@ class Extension {
 
         output.appendLine("running " + path.basename(sessionState.prgfilename));
 
-        var executable = settings.emulatorPath;
+        var executable = Utils.getAbsoluteFilename(settings.emulatorPath);
         var args = [
             sessionState.prgfilename
         ];
@@ -436,7 +436,7 @@ class Extension {
 
         output.appendLine("debugging " + path.basename(sessionState.prgfilename));
 
-        var executable = settings.debuggerPath;
+        var executable = Utils.getAbsoluteFilename(settings.debuggerPath);
 
         if (false == sessionState.debuggerRunning) {
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -166,8 +166,19 @@ var Utils = {
                 return filePath;
             }
         }
-    }
+    },
 
+    getAbsoluteFilename: function(filename) {
+        if(filename) {
+            if (path.isAbsolute(filename)) {
+                return filename;
+            } else {
+                return path.resolve(vscode.workspace.rootPath, filename);
+            }
+        } else {
+            return filename;
+        }
+    }
 };
 
 //-----------------------------------------------------------------------------------------------//

--- a/src/utils.js
+++ b/src/utils.js
@@ -169,12 +169,8 @@ var Utils = {
     },
 
     getAbsoluteFilename: function(filename) {
-        if(filename) {
-            if (path.isAbsolute(filename)) {
-                return filename;
-            } else {
-                return path.resolve(vscode.workspace.rootPath, filename);
-            }
+        if(filename && !path.isAbsolute(filename)) {
+            return path.resolve(vscode.workspace.rootPath, filename);
         } else {
             return filename;
         }


### PR DESCRIPTION
I think this might helps when you want to run tools like acme or c64debugger from inside your c64 project. I encountered this problem in spawn function. It seems that needs absolute path to application.

