### PR TITLE
New option for adding global symbol definitions to workspace settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
 					"default": false,
 					"description": "Flag to enable verbose output of extension"
 				},
+				"c64.definitions": {
+					"type": "string",
+					"default": "",
+					"description": "Comma-separated list of symbols to define, e.g. A=1,B=4"
+				},
 				"c64.autoBuild": {
 					"type": "boolean",
 					"default": true,

--- a/src/extension.js
+++ b/src/extension.js
@@ -360,6 +360,15 @@ class Extension {
             "--vicelabels", sessionState.labelsFilename
         ];
 
+        if (settings.definitions) {
+            var defs = settings.definitions.split(",");
+            if (defs.length > 0) {
+                for (var i = 0; i < defs.length; i++) {
+                    args.push("-D" + defs[i].trim());
+                }
+            }
+        }
+
         for (var i=0, searchDir; searchDir=searchDirs[i]; i++) {
             args.push("-I");
             args.push(searchDir);
@@ -615,6 +624,8 @@ class Extension {
         if (true == settings.verbose && true == settings.autoBuild) {
             console.log("[C64] auto build enabled");
         }
+
+        settings.definitions = vscode.workspace.getConfiguration().get("c64.definitions") || "";
 
         settings.backgroundBuild = vscode.workspace.getConfiguration().get("c64.backgroundBuild")||true;
         if (true == settings.verbose && true == settings.backgroundBuild) {


### PR DESCRIPTION
It's useful for some code to pass through global symbol definitions to the assembler command line, e.g.

-DENABLE_MY_FEATURE=1

This patch adds this as an option so that settings can be saved in a project's workspace file.