### PR TITLE
Fix setting breakpoints and better symbol processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,5 +55,6 @@ All notable changes to the **VS64 Development Environment** extension will be do
 ## 0.1.13 Minor Update _(preview)_
 - Fixed setting breakpoints
 - Fixed handling acme 'serious error' diagnostics
+- Improved symbol and label detection
 - Added '!word' syntax highlighting
-- Added 16-bit values to address watches
+- Show both 8- and 16-bit values of address symbols when their size is unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@ All notable changes to the **VS64 Development Environment** extension will be do
 - Fixed setting breakpoints
 - Fixed handling acme 'serious error' diagnostics
 - Added '!word' syntax highlighting
+- Added 16-bit values to address watches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,5 @@ All notable changes to the **VS64 Development Environment** extension will be do
 ## 0.1.12 Minor Update _(preview)_
 - Fixed dependencies
 
+## 0.1.13 Minor Update _(preview)_
+- Fixed setting breakpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,5 @@ All notable changes to the **VS64 Development Environment** extension will be do
 
 ## 0.1.13 Minor Update _(preview)_
 - Fixed setting breakpoints
+- Fixed handling acme 'serious error' diagnostics
+- Added '!word' syntax highlighting

--- a/language/asm.grammar.json
+++ b/language/asm.grammar.json
@@ -118,7 +118,7 @@
 				},
 				{
 					"include": "#keywords-assignment-text"
-				},								
+				},
 				{
 					"include": "#keywords-control"
 				},
@@ -151,7 +151,7 @@
 			"patterns": [
 				{
 					"name": "keyword.instructions",
-					"match": "\\!(?i)[\\s]*\\b(8|08|by|byte|align|fill|fi)\\b"
+					"match": "\\!(?i)[\\s]*\\b(8|08|by|byte|16|wo|word|align|fill|fi)\\b"
 				}
 			]
 		},
@@ -162,7 +162,7 @@
 					"match": "\\!(?i)[\\s]*\\b(ct|convtab|pet|raw|scr|scrxor|tx|text)\\b"
 				}
 			]
-		},				
+		},
 		"keywords-control": {
 			"patterns": [
 				{
@@ -207,6 +207,6 @@
 				}
 			]
 		}
-	},	
+	},
 	"scopeName": "source.asm"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vs64",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vs64",
 	"displayName": "vs64",
 	"description": "VS64 - The C64 Development Environment",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"preview": true,
 	"publisher": "rosc",
 	"license": "GPL-3.0",

--- a/src/debug_info.js
+++ b/src/debug_info.js
@@ -97,7 +97,7 @@ class DebugInfo {
                         addressRefs = [];
                         debugInfo.sourceRef[source] = addressRefs;
                     }
-                    
+
                     continue;
 
                 } else if (statement.type == StatementType.LABEL) {
@@ -106,7 +106,7 @@ class DebugInfo {
 
                 } else if (statement.type == StatementType.ADDRESS) {
 
-                    var addressInfo = { 
+                    var addressInfo = {
                         address: statement.value,
                         source: source,
                         line: statement.line
@@ -169,7 +169,7 @@ class DebugInfo {
     }
 
     static parseReport(line) {
-        
+
         var tokens = [];
         var comment = null;
         var source = null;
@@ -232,7 +232,7 @@ class DebugInfo {
                 } else if (token == '!addr') {
                     element = { type: ElementType.KEYWORD_ADDR, desc: "keyword-addr" };
                 } else if (token == '!pet') {
-                    element = { type: ElementType.KEYWORD_PET, desc: "keyword-pet" };
+                    element = { type: ElementType.DATA_SIZE, value: 8, desc: "data-size" };
                 } else if (token == '!byte') {
                     element = { type: ElementType.DATA_SIZE, value: 8, desc: "data-size" };
                 } else if (token == '!08') {
@@ -297,14 +297,14 @@ class DebugInfo {
                 type: StatementType.LABEL,
                 name: elements[1].value,
                 line: elements[0].value,
-                desc: "label" 
+                desc: "label"
             };
-            
+
         } else if (elements.length >= 4 &&
             elements[1].type == ElementType.UNKNOWN &&
             elements[2].type == ElementType.EQUALS &&
             elements[3].type == ElementType.UNKNOWN) {
-       
+
             let num = DebugInfo.parseNumber(elements[3].value);
             if (null != num) {
 
@@ -318,13 +318,13 @@ class DebugInfo {
                 };
 
             }
-                
+
         } else if (elements.length >= 5 &&
             elements[1].type == ElementType.KEYWORD_ADDR &&
             elements[2].type == ElementType.UNKNOWN &&
             elements[3].type == ElementType.EQUALS &&
             elements[4].type == ElementType.UNKNOWN) {
-       
+
             let num = DebugInfo.parseNumber(elements[4].value);
             if (null != num) {
                 statement = {
@@ -333,10 +333,10 @@ class DebugInfo {
                     value: num,
                     isAddress: true,
                     line: elements[0].value,
-                    desc: "symbol" 
+                    desc: "symbol"
                 };
             }
-                
+
         } else if (elements.length >= 2 &&
                    elements[1].type == ElementType.UNKNOWN) {
 
@@ -379,7 +379,7 @@ class DebugInfo {
                 elements: elements
             };
         }
-        
+
         return statement;
     }
 
@@ -391,22 +391,22 @@ class DebugInfo {
 
         if (null == s) return null; // empty
         if (s.length > 16) return null; // overflow
-    
+
         var value = 0;
         var hexValue = 0;
-    
+
         var isHex = hex;
         var isNegative = false;
-    
+
         var i = 0;
-    
+
         if (s[i] == '-') {
             isNegative = true;
             i++;
         } else if (s[i] == '+') {
             i++;
         }
-    
+
         if (s[i] == '$') {
             isHex = true;
             i++;
@@ -414,13 +414,13 @@ class DebugInfo {
             isHex = true;
             i+=2;
         }
-    
+
         while (i<s.length) {
-    
+
             let c = s[i++];
-    
+
             var digit = 0;
-    
+
             if (c >= '0' && c <= '9') {
                 digit = (c-'0');
             } else if (c >= 'a' && c <= 'f') {
@@ -432,15 +432,15 @@ class DebugInfo {
             } else {
                 return null; // illegal character
             }
-    
+
             if (!isHex) value = (value * 10) + digit;
             hexValue = (hexValue * 16) + digit;
-    
+
         }
-    
+
         var result = (isHex ? hexValue : value);
         if (isNegative) result = -result;
-    
+
         return result;
     }
 

--- a/src/debug_info.js
+++ b/src/debug_info.js
@@ -120,7 +120,7 @@ class DebugInfo {
 
                     if (statement.symbol) {
                         debugInfo.symbols.push({
-                            name: statement.symbol.replace(':',''),
+                            name: statement.symbol,
                             value: statement.value,
                             isAddress: true,
                             source: source,
@@ -132,7 +132,7 @@ class DebugInfo {
                     for (var j=0, label; (label=labelStatements[j]); j++) {
                         label.address = statement.value;
                         debugInfo.labels.push({
-                            name: label.name.replace(':',''),
+                            name: label.name,
                             address: label.address,
                             source: source,
                             line: label.line
@@ -144,7 +144,7 @@ class DebugInfo {
                 } else if (statement.type == StatementType.SYMBOL) {
 
                     debugInfo.symbols.push({
-                        name: statement.name.replace(':',''),
+                        name: statement.name,
                         value: statement.value,
                         isAddress: statement.isAddress,
                         source: source,
@@ -198,9 +198,11 @@ class DebugInfo {
                 if ("=,".indexOf(line[i]) >= 0) {
                     tokens.push(line[i]);
                     i++;
+                } else if (line[i] == ':') {
+                    i++; // ignore any ':'
                 } else {
                     var pos1 = i;
-                    while (i<line.length && " \t\r\n,=;".indexOf(line[i])<0) { i++; }
+                    while (i<line.length && " \t\r\n,=;:".indexOf(line[i])<0) { i++; }
 
                     // break after '...' in long code line to find label
                     //    22  081b c4554d4220455841....string  !pet "Dumb example", 13, 0
@@ -394,7 +396,21 @@ class DebugInfo {
     }
 
     static isValidSymbol(token) {
-        return token.charAt(0) == '.' || token.endsWith(':');
+        if (token.charAt(0) == '.' || token.charAt(0) == '@' || token.charAt(0) == '_') {
+            return true;
+        }
+        var firstChar = token.charAt(0).toLowerCase();
+        if (firstChar < 'a' || firstChar > 'z') {
+            return false;
+        }
+        // instructions cannot be symbols or labels
+        if (token.length == 3
+            &&  ("adc,and,asl,bcc,bcs,beq,bit,bmi,bne,bpl,brk,bvc,bvs,clc,cld,cli,clv,cmp,cpx,cpy,dec,dex,"+
+                "dey,eor,inc,inx,iny,jmp,jsr,lda,ldx,ldy,lsr,nop,ora,pha,php,pla,plp,rol,ror,rti,rts,sbc,"+
+                "sec,sed,sei,sta,stx,sty,tax,tay,tsx,txa,txs,tya,").indexOf(token.toLowerCase()) >= 0) {
+            return false;
+        }
+        return true;
     }
 
     static parseNumber(s, hex) {

--- a/src/debug_info.js
+++ b/src/debug_info.js
@@ -380,6 +380,10 @@ class DebugInfo {
 
                 if (elements[4] && elements[4].type == ElementType.DATA_SIZE) {
                     statement.data_size = elements[4].value;
+                } else if (!elements[4] || elements[4].token.charAt(0) != '!') {
+                    // no data and no pseudo opcode so probably a label pointing at code
+                    statement.type = StatementType.LABEL;
+                    statement.name = statement.symbol;
                 }
             }
 

--- a/src/debug_info.js
+++ b/src/debug_info.js
@@ -201,6 +201,16 @@ class DebugInfo {
                 } else {
                     var pos1 = i;
                     while (i<line.length && " \t\r\n,=;".indexOf(line[i])<0) { i++; }
+
+                    // break after '...' in long code line to find label
+                    //    22  081b c4554d4220455841....string  !pet "Dumb example", 13, 0
+                    if (tokens.length == 2) {
+                        var posDots = line.indexOf('...',pos1);
+                        if (posDots > 0 && posDots < i) {
+                            i = posDots + 3;
+                        }
+                    }
+
                     var pos2 = i;
                     if (pos2>pos1) {
                         tokens.push(line.substr(pos1, pos2-pos1));

--- a/src/debug_info.js
+++ b/src/debug_info.js
@@ -269,7 +269,9 @@ class DebugInfo {
                         element = { type: ElementType.NUMBER, value: num, desc: "number" };
                     } else {
 
-                        if (2 == i && null != num) {
+                        // Note: The check for i<tokens.length (for labels) and "=" (for symbols) will make
+                        //  a hex letters only token like 'cafe' be detected as unknown instead of address
+                        if (2 == i && null != num && i < tokens.length && tokens[i] != "=") {
                             isCodeLine = true;
                             element = { type: ElementType.ADDRESS, value: DebugInfo.parseNumber(token, true), desc: "address" };
                         } else if ( 3 == i && isCodeLine) {

--- a/src/diagnostic_provider.js
+++ b/src/diagnostic_provider.js
@@ -48,6 +48,7 @@ class DiagnosticProvider {
         }
     }
 
+    // Serious error - File d:\Work\vs64\test\programs\src\test aaa 2.asm, line 46 (Zone <untitled>): Missing '{'.
     // Error - File d:\Work\vs64\test\programs\src\test aaa 2.asm, line 12 (Zone <untitled>): Value not defined (qloop).
     // Warning - File d:\Work\vs64\test\programs\src\test aaa 2.asm, line 16 (Zone <untitled>): Label name not in leftmost column.
 
@@ -67,6 +68,9 @@ class DiagnosticProvider {
         if (s.indexOf("error - file ") == 0) {
             err.isError = true;
             pos += 13;
+        } else if (s.indexOf("serious error - file ") == 0) {
+            err.isError = true;
+            pos += 21;
         } else if (s.indexOf("warning - file ") == 0) {
             err.isWarning = true;
             pos += 15;
@@ -151,7 +155,7 @@ class DiagnosticProvider {
                 err.text,
                 err.isWarning ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error
             ));
-    
+
         }
 
         return diagnostics;


### PR DESCRIPTION
Hi Roland, 

I've created a few fixes this weekend for some long standing issues I encountered while using vs64 last months.

Most of them are pretty straightforward, but the change related to "capitalization in DebugInfo" requires some explanation.
I had issues setting breakpoints during development. Sometimes it worked, sometimes not.
In DebugInfo the full path of each file with uppercased driveletter is used as an [index]. Later on the debug adapter also receives a full path but without this uppercase driveletter. This causes another array to be used to lookup the address for an breakpoint line. This fails miserably if there are multiple !source includes because this 2nd array has different ranges of linenumbers.
Uppercasing the driveletter here fixed this.

You also asked me before to remove the replace(':','') and add proper parsing. So I did, but this complicated some issues down the line.
For instance, the parser throws away whitespace. If there is a line that starts with "10 cafe" in the report, the parser cannot determine if this is a label "cafe" or address $cafe at this point. It picked address. The same occured with an actual define I had in my code "AD=5". This was also turned into an address line.
Actually in the report, the address would be at a different position than the label.

Since a label is not required to start with `.` or `@` and does not necessarily end with `:` the current behavior misses a lot of cases.
Actually acme allows just about anything before an instruction. Therefore I now assume anything is a label except instruction names.

If the data size is not known, it now shows both 8 and 16 bits values in the form: 12 / 1234.
A nice side effect is that you now can type in an address watch like $00FB and have it immediately show its pointer address from $FB/$FC.

Overall I believe vs64 really would benefit from these changes so I hope you will integrate them.

Regards,
Alexander

