### PR TITLE
Bugfixes

### DIFF
--- a/src/debug_info.js
+++ b/src/debug_info.js
@@ -380,10 +380,6 @@ class DebugInfo {
 
                 if (elements[4] && elements[4].type == ElementType.DATA_SIZE) {
                     statement.data_size = elements[4].value;
-                } else if (!elements[4] || elements[4].token.charAt(0) != '!') {
-                    // no data and no pseudo opcode so probably a label pointing at code
-                    statement.type = StatementType.LABEL;
-                    statement.name = statement.symbol;
                 }
             }
 

--- a/src/debug_info.js
+++ b/src/debug_info.js
@@ -41,6 +41,11 @@ const StatementType = {
     ADDRESS: 3
 };
 
+const OPCODES =
+    "adc,and,asl,bcc,bcs,beq,bit,bmi,bne,bpl,brk,bvc,bvs,clc,cld,cli,clv,cmp,cpx,cpy,dec,dex,"+
+    "dey,eor,inc,inx,iny,jmp,jsr,lda,ldx,ldy,lsr,nop,ora,pha,php,pla,plp,rol,ror,rti,rts,sbc,"+
+    "sec,sed,sei,sta,stx,sty,tax,tay,tsx,txa,txs,tya,";
+
 //-----------------------------------------------------------------------------------------------//
 // Debug Info
 //-----------------------------------------------------------------------------------------------//
@@ -398,19 +403,11 @@ class DebugInfo {
     }
 
     static isValidSymbol(token) {
-        if (token.charAt(0) == '.' || token.charAt(0) == '@' || token.charAt(0) == '_') {
-            return true;
-        }
-        var firstChar = token.charAt(0).toLowerCase();
-        if (firstChar < 'a' || firstChar > 'z') {
-            return false;
-        }
-        // instructions cannot be symbols or labels
-        if (token.length == 3
-            &&  ("adc,and,asl,bcc,bcs,beq,bit,bmi,bne,bpl,brk,bvc,bvs,clc,cld,cli,clv,cmp,cpx,cpy,dec,dex,"+
-                "dey,eor,inc,inx,iny,jmp,jsr,lda,ldx,ldy,lsr,nop,ora,pha,php,pla,plp,rol,ror,rti,rts,sbc,"+
-                "sec,sed,sei,sta,stx,sty,tax,tay,tsx,txa,txs,tya,").indexOf(token.toLowerCase()) >= 0) {
-            return false;
+        if (token.charAt(0) != '.' && token.charAt(0) != '_') {
+            let ch = token.charAt(0).toLowerCase();
+            if (ch < 'a' || ch > 'z' || (token.length == 3 && OPCODES.indexOf(token.toLowerCase()) >= 0)) {
+                return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
I've reverted the change to convert some address symbols into labels (to reduce the size of the Symbols list). This change makes it impossible to put a breakpoint on a code line that starts with a label.
The list of Symbols is now a lot larger because more symbols are parsed correctly.

I've also reworked the isValidSymbol function and put the opcodes in a constant.